### PR TITLE
Main shell script change

### DIFF
--- a/plugin.sh
+++ b/plugin.sh
@@ -31,7 +31,7 @@ copy_folder(){
   pack_folder=$PWD"/compressed_pack"
   compress_plugin_folder=$pack_folder/"wlrp-perfect-brand"
   if [ -d "$pack_folder" ]; then
-    rm -r "$pack_pack_folder"
+    rm -r "$pack_folder"
   fi
   mkdir "$pack_folder"
   mkdir "$compress_plugin_folder"

--- a/plugin.sh
+++ b/plugin.sh
@@ -7,8 +7,8 @@ composer_lock_path=$current_dir"/composer.lock"
 vendor_path=$current_dir"/vendor"
 
 composer_run(){
-  rm $composer_lock_path
-  rm -r $vendor_path
+  rm "$composer_lock_path"
+  rm -r "$vendor_path"
   # shellcheck disable=SC2164
   cd "$current_dir"
   composer install --no-dev


### PR DESCRIPTION
- There was a typo in the script that generates the pack (pack_pack_folder instead of pack_folder)
- During pack generation, script should remove existing compressed_pack folder before creating new one
- But the variable for existing compressed_pack folder had a typo
- Due to this, instead of deleting the existing compressed_pack folder, new files were copied into existing directory structure, causing App folder to nest within itself